### PR TITLE
Added example for adding a custom items control to the RR where the items are commands added via context.

### DIFF
--- a/ExamplePlugins/ExampleDiagram/Design/InteractiveNodeView.xaml
+++ b/ExamplePlugins/ExampleDiagram/Design/InteractiveNodeView.xaml
@@ -6,10 +6,11 @@
              xmlns:local="clr-namespace:ExamplePlugins.ExampleDiagram.Design"
              xmlns:core="clr-namespace:NationalInstruments.Core;assembly=NationalInstruments.Core"
              mc:Ignorable="d" 
-             Height="50" Width="80">
+             Height="NaN" Width="80">
     <Border BorderBrush="DarkGray" BorderThickness="1">
         <Grid Background="Transparent">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -19,7 +20,8 @@
             </Grid>
             <TextBlock Margin="0,0,4,0" HorizontalAlignment="Right" Text="Node Info" />
             <TextBlock HorizontalAlignment="Center" Grid.Row="1" FontSize="8" Text="Node Info2" />
-            <CheckBox VerticalAlignment="Bottom" Grid.Row="2" Content="Active" IsChecked="{Binding IsActive}" />
+            <TextBlock Grid.Row="2" Text="{Binding Sound}"/>
+            <CheckBox VerticalAlignment="Bottom" Grid.Row="3" Content="Active" IsChecked="{Binding IsActive}" />
         </Grid>
     </Border>
 </UserControl>

--- a/ExamplePlugins/ExampleDiagram/Design/InteractiveNodeViewModel.cs
+++ b/ExamplePlugins/ExampleDiagram/Design/InteractiveNodeViewModel.cs
@@ -47,12 +47,29 @@ namespace ExamplePlugins.ExampleDiagram.Design
             }
         }
 
+        public string Sound
+        {
+            get { return Node.Sound; }
+            set
+            {
+                using (var transaction = Node.TransactionManager.BeginTransaction("Set Sound", TransactionPurpose.User))
+                {
+                    Node.Sound = value;
+                    transaction.Commit();
+                }
+            }
+        }
+
         public override void ModelPropertyChanged(Element modelElement, string propertyName, TransactionItem transactionItem)
         {
             base.ModelPropertyChanged(modelElement, propertyName, transactionItem);
             if (propertyName == "IsActive")
             {
                 NotifyPropertyChanged("IsActive");
+            }
+            else if (propertyName == nameof(Sound))
+            {
+                NotifyPropertyChanged(nameof(Sound));
             }
         }
 
@@ -112,6 +129,65 @@ namespace ExamplePlugins.ExampleDiagram.Design
             LabelTitle = "Is Active"
         };
 
+        public static readonly ICommandEx SoundSelectionGroupCommand = new ShellRelayCommand()
+        {
+            UniqueId = "ExamplePlugins.SoundSelectionGroupCommand",
+            LabelTitle = "Select the animal sound"
+        };
+
+        #region Sound commands
+
+        private static readonly ICommandEx WoofCommand = CreateSoundCommand("WoofCommand", "Dog goes woof");
+
+        private static readonly ICommandEx MeowCommand = CreateSoundCommand("MeowCommand", "Cat goes meow");
+
+        private static readonly ICommandEx TweetCommand = CreateSoundCommand("TweetCommand", "Bird goes tweet");
+        
+        private static readonly ICommandEx SqueakCommand = CreateSoundCommand("SqueakCommand", "Mouse goes squeak");
+
+        private static readonly ICommandEx MooCommand = CreateSoundCommand("MooCommand", "Cow goes moo");
+
+        private static readonly ICommandEx CroakCommand = CreateSoundCommand("CroakCommand", "Frog goes croak");
+
+        private static readonly ICommandEx TootCommand = CreateSoundCommand("TootCommand", "Elephant goes toot");
+
+        private static readonly ICommandEx QuackCommand = CreateSoundCommand("QuackCommand", "Duck say quack");
+
+        private static readonly ICommandEx BlubCommand = CreateSoundCommand("BlubCommand", "Fish go blub");
+
+        private static readonly ICommandEx OwowowCommand = CreateSoundCommand("OwowowCommand", "Seal goes ow ow ow");
+
+        private static readonly ICommandEx FoxCommand = new ShellRelayCommand(OnFoxCommand)
+        {
+            UniqueId = "ExamplePlugins.FoxCommand",
+            LabelTitle = "Fox says..."
+        };
+
+        private static ICommandEx CreateSoundCommand(string name, string phrase)
+        {
+            return new ShellSelectionRelayCommand(OnSoundCommand)
+            {
+                UniqueId = $"ExamplePlugins.{name}",
+                LabelTitle = phrase
+            };
+        }
+
+        private static void OnSoundCommand(ICommandParameter parameter, IEnumerable<IViewModel> selection, ICompositionHost host, DocumentEditSite site)
+        {
+            var viewModel = selection.FirstOrDefault() as InteractiveNodeViewModel;
+            if (viewModel != null)
+            {
+                viewModel.Sound = string.Concat(parameter.LabelTitle.Split(new[] { ' ' }, 3).Skip(2));
+            }
+        }
+
+        private static void OnFoxCommand(ICommandParameter parameter, ICompositionHost host, DocumentEditSite site)
+        {
+            NIMessageBox.Show("What does the fox say?");
+        }
+
+        #endregion
+
         public static bool UpdateIsActive(ICommandParameter parameter, IEnumerable<IViewModel> selection, ICompositionHost host, DocumentEditSite site)
         {
             var checkableParameter = parameter as ICheckableCommandParameter;
@@ -159,6 +235,21 @@ namespace ExamplePlugins.ExampleDiagram.Design
                 using (context.AddGroup(ConfigurationItemsGroup))
                 {
                     context.Add(IsActiveCommand, CheckBoxFactory.ForConfigurationPane);
+
+                    using (context.AddGroup(SoundSelectionGroupCommand, ListBoxLayoutFactory.ForConfigurationPane))
+                    {
+                        context.Add(WoofCommand);
+                        context.Add(MeowCommand);
+                        context.Add(TweetCommand);
+                        context.Add(SqueakCommand);
+                        context.Add(MooCommand);
+                        context.Add(CroakCommand);
+                        context.Add(TootCommand);
+                        context.Add(QuackCommand);
+                        context.Add(BlubCommand);
+                        context.Add(OwowowCommand);
+                        context.Add(FoxCommand);
+                    }
                 }
             }
         }

--- a/ExamplePlugins/ExampleDiagram/Design/ListBoxItem.cs
+++ b/ExamplePlugins/ExampleDiagram/Design/ListBoxItem.cs
@@ -1,0 +1,87 @@
+﻿using NationalInstruments.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Input;
+
+namespace ExamplePlugins.ExampleDiagram.Design
+{
+    public class ListBoxItem : System.Windows.Controls.ListBoxItem, ICommandSourceEx
+    {
+        public static readonly DependencyProperty CommandProperty = 
+            DependencyProperty.Register("Command", typeof(ICommand), typeof(ListBoxItem), new FrameworkPropertyMetadata(default(ICommand), OnCommandChanged));
+
+        public static readonly DependencyProperty CommandParameterProperty =
+            DependencyProperty.Register("CommandParameter", typeof(object), typeof(ListBoxItem), new PropertyMetadata(default(object), OnCommandParameterChanged));
+
+        public static readonly DependencyProperty CommandTargetProperty =
+            DependencyProperty.Register("CommandTarget", typeof(IInputElement), typeof(ListBoxItem), new PropertyMetadata(default(IInputElement)));
+
+        public ICommand Command
+        {
+            get { return (ICommand)GetValue(CommandProperty); }
+            set { SetValue(CommandProperty, value); }
+        }
+
+        public object CommandParameter
+        {
+            get { return GetValue(CommandParameterProperty); }
+            set { SetValue(CommandParameterProperty, value); }
+        }
+        
+        public IInputElement CommandTarget
+        {
+            get { return (IInputElement)GetValue(CommandTargetProperty); }
+            set { SetValue(CommandTargetProperty, value); }
+        }
+
+        private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+
+        }
+
+        private static void OnCommandParameterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+
+        }
+
+        public ListBoxItem()
+        {
+            SetBindings();
+        }
+
+        private void SetBindings()
+        {
+            SetBinding(ContentProperty, new Binding("Command.LabelTitle") { Source = this });
+        }
+
+        protected override void OnMouseDoubleClick(MouseButtonEventArgs e)
+        {
+            ExecuteCommand();
+            e.Handled = true;
+            base.OnMouseDoubleClick(e);
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter || e.Key == Key.Return)
+            {
+                ExecuteCommand();
+                e.Handled = true;
+            }
+            base.OnKeyDown(e);
+        }
+
+        internal void ExecuteCommand()
+        {
+            if (Command != null && Command.CanExecute(CommandParameter))
+            {
+                Command.Execute(CommandParameter);
+            }
+        }
+    }
+}

--- a/ExamplePlugins/ExampleDiagram/Design/ListBoxVisualLayoutFactory.cs
+++ b/ExamplePlugins/ExampleDiagram/Design/ListBoxVisualLayoutFactory.cs
@@ -1,0 +1,71 @@
+﻿using NationalInstruments.Shell;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NationalInstruments.Core;
+using ExamplePlugins.ExampleDiagram.Shell;
+using NationalInstruments.Design;
+using System.Windows.Data;
+using NationalInstruments.Controls.Shell;
+
+namespace ExamplePlugins.ExampleDiagram.Design
+{
+    public class ListBoxLayoutFactory : VisualLayoutFactory
+    {
+        private static readonly Lazy<ListBoxLayoutFactory> _forConfigurationPane = new Lazy<ListBoxLayoutFactory>();
+
+        /// <summary>
+        /// Gets the default facotry for controls in the configuration pane
+        /// </summary>
+        public static ICommandVisualLayoutFactory ForConfigurationPane => _forConfigurationPane.Value;
+
+        public ListBoxLayoutFactory()
+        {
+            CreateLabel = false;
+        }
+
+        public override IVisualCollectionProvider GetVisualCollectionProvider(PlatformVisual visual)
+        {
+            var listBox = (ListBox)GetCommandSourceForVisual(visual);
+            return new CollectionOrderVisualCollectionProvider(listBox.Items);
+        }
+
+        public override ICommandVisualFactory GetDefaultVisualFactory(ICommandEx command)
+        {
+            return ListBoxItemFactory.ForConfigurationPane;
+        }
+
+        protected override PlatformVisual CreateVisual()
+        {
+            // Arbitrarily setting max to 120 to encourage a visible vertical scrollbar.
+            return new ListBox() { MaxHeight = 120 };
+        }
+    }
+
+    public class ListBoxItemFactory : VisualFactory
+    {
+        private static readonly Lazy<ListBoxItemFactory> _forConfigurationPane = new Lazy<ListBoxItemFactory>();
+
+        public static ICommandVisualFactory ForConfigurationPane => _forConfigurationPane.Value;
+
+        public ListBoxItemFactory()
+        {
+            CreateLabel = false;
+        }
+
+        protected override PlatformVisual CreateVisual()
+        {
+            return new ListBoxItem();
+        }
+
+        public override void Attach(ICommandEx command, PlatformVisual visual, ICommandAttachContext context)
+        {
+            var listBoxItem = (ListBoxItem)GetCommandSourceForVisual(visual);
+            listBoxItem.Command = command;
+            listBoxItem.CommandParameter = new ChoiceCommandParameter(command);
+            base.Attach(command, visual, context);
+        }
+    }
+}

--- a/ExamplePlugins/ExampleDiagram/Shell/ListBox.xaml
+++ b/ExamplePlugins/ExampleDiagram/Shell/ListBox.xaml
@@ -1,0 +1,10 @@
+﻿<UserControl x:Class="ExamplePlugins.ExampleDiagram.Shell.ListBox"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ExamplePlugins.ExampleDiagram.Shell"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <ListBox x:Name="PART_ListBox" SelectionChanged="OnListBoxSelectionChanged" SelectionMode="Single"/>
+</UserControl>

--- a/ExamplePlugins/ExampleDiagram/Shell/ListBox.xaml.cs
+++ b/ExamplePlugins/ExampleDiagram/Shell/ListBox.xaml.cs
@@ -1,0 +1,94 @@
+﻿using NationalInstruments.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace ExamplePlugins.ExampleDiagram.Shell
+{
+    /// <summary>
+    /// Wrapper for the ListBox that simplifies the control by only allowing single selection.
+    /// </summary>
+    public partial class ListBox : UserControl, ICommandSourceEx
+    {
+        public static readonly DependencyProperty SelectedItemProperty = 
+            DependencyProperty.Register("SelectedItem", typeof(object), typeof(ListBox), new FrameworkPropertyMetadata(default(object), OnSelectedItemChanged));
+
+        public object SelectedItem
+        {
+            get { return (object)GetValue(SelectedItemProperty); }
+            set { SetValue(SelectedItemProperty, value); }
+        }
+
+        public ItemCollection Items => PART_ListBox.Items;
+
+        private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var listBox = (ListBox)d;
+            listBox.PART_ListBox.SelectedItem = e.NewValue;
+        }
+
+        #region ICommandSourceEx implementation
+
+        public static readonly DependencyProperty CommandProperty =
+            DependencyProperty.Register("Command", typeof(ICommand), typeof(ListBoxItem), new FrameworkPropertyMetadata(default(ICommand), OnCommandChanged));
+
+        public static readonly DependencyProperty CommandParameterProperty =
+            DependencyProperty.Register("CommandParameter", typeof(object), typeof(ListBoxItem), new PropertyMetadata(default(object), OnCommandParameterChanged));
+
+        public static readonly DependencyProperty CommandTargetProperty =
+            DependencyProperty.Register("CommandTarget", typeof(IInputElement), typeof(ListBoxItem), new PropertyMetadata(default(IInputElement)));
+
+        public ICommand Command
+        {
+            get { return (ICommand)GetValue(CommandProperty); }
+            set { SetValue(CommandProperty, value); }
+        }
+
+        public object CommandParameter
+        {
+            get { return GetValue(CommandParameterProperty); }
+            set { SetValue(CommandParameterProperty, value); }
+        }
+
+        public IInputElement CommandTarget
+        {
+            get { return (IInputElement)GetValue(CommandTargetProperty); }
+            set { SetValue(CommandTargetProperty, value); }
+        }
+
+        private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+
+        }
+
+        private static void OnCommandParameterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+
+        }
+        #endregion
+
+        public ListBox()
+        {
+            InitializeComponent();
+        }
+
+        private void OnListBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (SelectedItem != PART_ListBox.SelectedItem)
+            {
+                SelectedItem = PART_ListBox.SelectedItem;
+            }
+        }
+    }
+}

--- a/ExamplePlugins/ExampleDiagram/SourceModel/InteractiveNode.cs
+++ b/ExamplePlugins/ExampleDiagram/SourceModel/InteractiveNode.cs
@@ -17,6 +17,7 @@ namespace ExamplePlugins.ExampleDiagram.SourceModel
         private Terminal _output2Terminal;
 
         private bool _isActive;
+        private string _sound;
 
         /// <summary>
         /// This is the specific type identifier for the node
@@ -30,6 +31,13 @@ namespace ExamplePlugins.ExampleDiagram.SourceModel
                 (obj, value) => obj.IsActive = (bool)value,
                 PropertySerializers.BooleanSerializer,
                 false);
+
+        public static readonly PropertySymbol SoundPropertySymbol =
+            ExposeStaticProperty<InteractiveNode>(
+                "Sound", obj => obj.Sound,
+                (obj, value) => obj.Sound = (string)value,
+                PropertySerializers.StringSerializer,
+                string.Empty);
         
         /// <summary>
         /// The standard constructor.  To construct a new instance use the static Create method to enable
@@ -49,6 +57,20 @@ namespace ExamplePlugins.ExampleDiagram.SourceModel
                     var wasIsActive = _isActive;
                     _isActive = value;
                     TransactionRecruiter.EnlistPropertyItem(this, "IsActive", wasIsActive, _isActive, (v, r) => { _isActive = v; }, TransactionHints.None);
+                }
+            }
+        }
+
+        public string Sound
+        {
+            get { return _sound; }
+            set
+            {
+                if (_sound != value)
+                {
+                    var oldSound = _sound;
+                    _sound = value;
+                    TransactionRecruiter.EnlistPropertyItem(this, "Sound", oldSound, _sound, (v, r) => { _sound = v; }, TransactionHints.None);
                 }
             }
         }

--- a/ExamplePlugins/ExamplePlugins.csproj
+++ b/ExamplePlugins/ExamplePlugins.csproj
@@ -103,6 +103,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="ExampleDiagram\Shell\ListBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="ExampleToolWindow\SelectionTrackingToolWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -121,8 +125,13 @@
       <DependentUpon>InteractiveNodeView.xaml</DependentUpon>
     </Compile>
     <Compile Include="ExampleDiagram\Design\InteractiveNodeViewModel.cs" />
+    <Compile Include="ExampleDiagram\Design\ListBoxItem.cs" />
+    <Compile Include="ExampleDiagram\Design\ListBoxVisualLayoutFactory.cs" />
     <Compile Include="ExampleDiagram\Design\SplineWire\SplineWireControl.cs" />
     <Compile Include="ExampleDiagram\Design\SplineWire\SplineWireViewModel.cs" />
+    <Compile Include="ExampleDiagram\Shell\ListBox.xaml.cs">
+      <DependentUpon>ListBox.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ExampleDiagram\SourceModel\ExampleDiagramDefinition.cs" />
     <Compile Include="ExampleDiagram\Design\ExampleDiagramDocument.cs" />
     <Compile Include="ExampleDiagram\Design\ExampleDiagramEditControl.cs" />

--- a/InstallLocation.targets
+++ b/InstallLocation.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <InstallLocation>C:\Program Files\National Instruments\Next Generation LabVIEW Features Technology Preview</InstallLocation>
+    <InstallLocation>C:\dev\R4\Releases\Cycle5\Binaries\WPF\LabVIEW\Debug</InstallLocation>
   </PropertyGroup>
 </Project>

--- a/InstallLocation.targets
+++ b/InstallLocation.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <InstallLocation>C:\dev\R4\Releases\Cycle5\Binaries\WPF\LabVIEW\Debug</InstallLocation>
+    <InstallLocation>C:\Program Files\National Instruments\Next Generation LabVIEW Features Technology Preview</InstallLocation>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidevlabs/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a list box control to the configuration page for the interactive node.  Items are added as commands to the context and the list box is added as a group.

### Why should this Pull Request be merged?

Example was requested by customer. [Link to request](https://forums.ni.com/t5/NIDevLabs/Custom-object-in-Configuration-panel/gpm-p/3454922)

### What testing has been done?

Only manual testing has been performed.
